### PR TITLE
Support DATA_UPLOAD_MAX_MEMORY_MiB, only, in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,9 +138,9 @@ TWO_FACTOR_LOGIN_MAX_SECONDS=60
 # Value should be a comma-separated list of host names.
 CSP_ADDITIONAL_HOSTS=
 
-# Increase if users are having trouble uploading BookWyrm export files.
-# Default value is 100MB
-DATA_UPLOAD_MAX_MEMORY_SIZE=104857600
-
 # Time before being logged out (in seconds)
 # SESSION_COOKIE_AGE=2592000   # current default: 30 days
+
+# Maximum allowed memory for file uploads (increase if users are having trouble
+# uploading BookWyrm export files).
+# DATA_UPLOAD_MAX_MEMORY_MiB=100

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -446,4 +446,6 @@ if HTTP_X_FORWARDED_PROTO:
 # user with the same username - in which case you should change it!
 INSTANCE_ACTOR_USERNAME = "bookwyrm.instance.actor"
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_SIZE", 104857600)
+# We only allow specifying DATA_UPLOAD_MAX_MEMORY_SIZE in MiB from .env
+# (note the difference in variable names).
+DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_MiB", 100) << 20


### PR DESCRIPTION
-----
Copy of bookwyrm-social#3251, in case it's better to merge here first.